### PR TITLE
Updated task to work with new Slack webhooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,7 @@ In your project's Gruntfile, add a section named `plugin` to the data object pas
 grunt.initConfig({
   slack: {
     options: {
-        token: 'slack token', // get one from here: https://typekit.slack.com/services
-        domain: 'domain', // https://domain.slack.com
+        webhook: 'https://hooks.slack.com/...', // Add a new Service Incoming WebHooks, copy the Webhook URL
         channel: '@slackbot',
         username: 'webhookbot',
         icon_emoji: ':ghost:',

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# grunt-slack-hook
+# grunt-slack-webhook
 
 > Grunt plugin that can push messages to [slack](http://slack.com/) service using web hooks.
 
@@ -10,13 +10,13 @@ This plugin requires Grunt `~0.4.2`
 If you haven't used [Grunt](http://gruntjs.com/) before, be sure to check out the [Getting Started](http://gruntjs.com/getting-started) guide, as it explains how to create a [Gruntfile](http://gruntjs.com/sample-gruntfile) as well as install and use Grunt plugins. Once you're familiar with that process, you may install this plugin with this command:
 
 ```shell
-npm install grunt-slack-hook --save-dev
+npm install grunt-slack-webhook --save-dev
 ```
 
 Once the plugin has been installed, it may be enabled inside your Gruntfile with this line of JavaScript:
 
 ```js
-grunt.loadNpmTasks('grunt-slack-hook');
+grunt.loadNpmTasks('grunt-slack-webhook');
 ```
 
 ## The "plugin" task

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 > Grunt plugin that can push messages to [slack](http://slack.com/) service using web hooks.
 
+__Note:__ This is a fork of the original [grunt-slack-hook](https://github.com/pwalczyszyn/grunt-slack-hook) by pwalczyszyn. It's working with the current version of Slack that uses webhook-urls instead of access tokens.
+
 ## Getting Started
 This plugin requires Grunt `~0.4.2`
 

--- a/package.json
+++ b/package.json
@@ -1,24 +1,24 @@
 {
-    "name": "grunt-slack-hook",
+    "name": "grunt-slack-webhook",
     "description": "Grunt plugin that can push messages to slack.com service using web hooks.",
-    "version": "0.0.3",
-    "homepage": "https://github.com/pwalczyszyn/grunt-slack-hook",
+    "version": "0.0.4",
+    "homepage": "https://github.com/kriskbx/grunt-slack-webhook",
     "author": {
-        "name": "Piotr Walczyszyn",
-        "email": "piotr@outof.me",
-        "url": "http://outof.me"
+        "name": "Kris Siepert",
+        "email": "m@kris cool",
+        "url": "https://github.com/kriskbx"
     },
     "repository": {
         "type": "git",
-        "url": "https://github.com/pwalczyszyn/grunt-slack-hook.git"
+        "url": "https://github.com/kriskbx/grunt-slack-webhook.git"
     },
     "bugs": {
-        "url": "https://github.com/pwalczyszyn/grunt-slack-hook/issues"
+        "url": "https://github.com/kriskbx/grunt-slack-webhook/issues"
     },
     "licenses": [
         {
             "type": "MIT",
-            "url": "https://github.com/pwalczyszyn/grunt-slack-hook/blob/master/LICENSE-MIT"
+            "url": "https://github.com/kriskbx/grunt-slack-webhook/blob/master/LICENSE-MIT"
     }
     ],
     "main": "Gruntfile.js",

--- a/tasks/slack.js
+++ b/tasks/slack.js
@@ -7,11 +7,8 @@ module.exports = function (grunt) {
         var options = this.options(),
             invalids = [];
 
-        if (!options.domain) {
-            invalids.push('domain');
-        }
-        if (!options.token) {
-            invalids.push('token');
+        if (!options.webhook) {
+            invalids.push('webhook');
         }
         if (!options.channel) {
             invalids.push('channel');
@@ -24,7 +21,7 @@ module.exports = function (grunt) {
         // We are good to go
         var done = this.async(),
             message = grunt.option('message') || '',
-            url = 'https://' + options.domain + '.slack.com/services/hooks/incoming-webhook?token=' + options.token,
+            url = options.webhook,
             data = {
                 channel: options.channel,
                 text: this.data.text.replace('{{message}}', message)


### PR DESCRIPTION
Slack has changed it's Incoming webhooks integration. It uses now a "Webhook URL" instead of a token. The updated code works with the current slack version.